### PR TITLE
Initial minor fixes for Rust

### DIFF
--- a/analyze_rust.py
+++ b/analyze_rust.py
@@ -70,6 +70,8 @@ def emit_llvm_ir(source_file, output_file):
         subprocess.run(
             [
                 "rustc",
+                # Ensure same crate name to avoid the difference in the mangled names.
+                "--crate-name=llvm_export",
                 "--emit=llvm-ir",
                 source_file,
                 "-o",

--- a/analyze_rust.py
+++ b/analyze_rust.py
@@ -126,8 +126,8 @@ def rename_miri_output(source_file, base_file_name):
     """Rename the log files to include the source file name."""
     log_file = f"{base_file_name}_miri_output.log"
     stderr_log_file = f"{base_file_name}_stderr.log"
-    os.rename('stdout.log', log_file)
-    os.rename('stderr.log', stderr_log_file)
+    shutil.move('stdout.log', log_file)
+    shutil.move('stderr.log', stderr_log_file)
     logging.info(f"MIRI output saved to {stderr_log_file}.")
     return stderr_log_file
 
@@ -152,7 +152,7 @@ def run_miri(source_file, base_file_name):
         return miri_output
 
     except Exception as e:
-        logging.error(f"An error occurred while running MIRI: {e}")
+        logging.error(f"An error occurred while running MIRI: {e}", exc_info=True)
 
     finally:
         os.chdir("..")


### PR DESCRIPTION
Rust's compiler mangles function names with a [metadata](https://doc.rust-lang.org/rustc/codegen-options/index.html#metadata) which is a [hash-like string](https://rustc-dev-guide.rust-lang.org/backend/libs-and-metadata.html#stable-crate-id) calculated for each crate's version. While there are different ways to fix it, when compiling a single file, the easiest way is to use a fixed crate name.

For a bit more complicated scenarios, the identical functions should probably be determined during compilation and alive2 be manually instructed for comparison ([see](https://github.com/AliveToolkit/alive2/discussions/1106)).